### PR TITLE
Update Node version in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: The location of pubspec.yml include file name.
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
   
 branding:


### PR DESCRIPTION
This upgrade is needed because _Node.js 16 actions are deprecated_.